### PR TITLE
Add xUnit test projects for TerrainEngine Common and TileBuilders

### DIFF
--- a/TerrainEngine/Common.Tests/Common.Tests.csproj
+++ b/TerrainEngine/Common.Tests/Common.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TerrainEngine/Common.Tests/Interfaces/FilenameTests.cs
+++ b/TerrainEngine/Common.Tests/Interfaces/FilenameTests.cs
@@ -1,0 +1,50 @@
+using Kuoste.TerrainEngine.Common.Interfaces;
+using Xunit;
+
+namespace Kuoste.TerrainEngine.Common.Tests.Interfaces;
+
+public class FilenameTests
+{
+    private const string TileName = "L4133B3_4";
+    private const string Version = "1";
+
+    [Fact]
+    public void DemDsmBuilder_Filename_ReturnsExpectedString()
+    {
+        Assert.Equal("L4133B3_4_DemDsm_v1.voxelgrid", IDemDsmBuilder.Filename(TileName, Version));
+    }
+
+    [Fact]
+    public void BuildingsBuilder_Filename_ReturnsExpectedString()
+    {
+        Assert.Equal("L4133B3_4_buildings_v1.geojson", IBuildingsBuilder.Filename(TileName, Version));
+    }
+
+    [Fact]
+    public void TreeBuilder_Filename_ReturnsExpectedString()
+    {
+        Assert.Equal("L4133B3_4_trees_v1.geojson", ITreeBuilder.Filename(TileName, Version));
+    }
+
+    [Fact]
+    public void WaterAreasBuilder_Filename_ReturnsExpectedString()
+    {
+        Assert.Equal("L4133B3_4_waterareas_v1.geojson", IWaterAreasBuilder.Filename(TileName, Version));
+    }
+
+    [Fact]
+    public void RasterBuilder_Filename_WithTerrainTypeSpecifier_ReturnsExpectedString()
+    {
+        Assert.Equal(
+            "L4133B3_4_terraintype_v1.asp",
+            IRasterBuilder.Filename(TileName, IRasterBuilder.SpecifierTerrainType, Version));
+    }
+
+    [Fact]
+    public void RasterBuilder_Filename_WithBuildingsRoadsSpecifier_ReturnsExpectedString()
+    {
+        Assert.Equal(
+            "L4133B3_4_buildingsroads_v1.asp",
+            IRasterBuilder.Filename(TileName, IRasterBuilder.SpecifierBuildingsRoads, Version));
+    }
+}

--- a/TerrainEngine/Common.Tests/Tiles/TileCommonTests.cs
+++ b/TerrainEngine/Common.Tests/Tiles/TileCommonTests.cs
@@ -1,0 +1,29 @@
+using Kuoste.TerrainEngine.Common.Tiles;
+using Xunit;
+
+namespace Kuoste.TerrainEngine.Common.Tests.Tiles;
+
+public class TileCommonTests
+{
+    [Fact]
+    public void EdgeLength_IsOneThousand()
+    {
+        Assert.Equal(1000, TileCommon.EdgeLength);
+    }
+
+    [Fact]
+    public void Constructor_StoresAllProperties()
+    {
+        const int alphamapRes = 256;
+        const string intermediate = "/data/intermediate";
+        const string original = "/data/original";
+        const string version = "2";
+
+        var common = new TileCommon(alphamapRes, intermediate, original, version);
+
+        Assert.Equal(alphamapRes, common.AlphamapResolution);
+        Assert.Equal(intermediate, common.DirectoryIntermediate);
+        Assert.Equal(original, common.DirectoryOriginal);
+        Assert.Equal(version, common.Version);
+    }
+}

--- a/TerrainEngine/Common.Tests/Tiles/TileTests.cs
+++ b/TerrainEngine/Common.Tests/Tiles/TileTests.cs
@@ -1,0 +1,55 @@
+using Kuoste.TerrainEngine.Common.Tiles;
+using System.Threading;
+using Xunit;
+
+namespace Kuoste.TerrainEngine.Common.Tests.Tiles;
+
+public class TileTests
+{
+    [Fact]
+    public void CompletedRequired_IsThree()
+    {
+        var tile = new Tile();
+        Assert.Equal(3, tile.CompletedRequired);
+    }
+
+    [Fact]
+    public void IsCompleted_WhenCompletedCountBelowRequired_ReturnsFalse()
+    {
+        var tile = new Tile();
+        tile.CompletedCount = 2;
+        Assert.False(tile.IsCompleted);
+    }
+
+    [Fact]
+    public void IsCompleted_WhenCompletedCountEqualsRequired_ReturnsTrue()
+    {
+        var tile = new Tile();
+        Interlocked.Exchange(ref tile.CompletedCount, 3);
+        Assert.True(tile.IsCompleted);
+    }
+
+    [Fact]
+    public void IsCompleted_WhenCompletedCountExceedsRequired_ReturnsTrue()
+    {
+        var tile = new Tile();
+        Interlocked.Exchange(ref tile.CompletedCount, 5);
+        Assert.True(tile.IsCompleted);
+    }
+
+    [Fact]
+    public void Clear_EmptiesCollectionsAndNullsData()
+    {
+        var tile = new Tile();
+        tile.Buildings.Add(default(Tile.Building));
+
+        tile.Clear();
+
+        Assert.Empty(tile.Buildings);
+        Assert.Empty(tile.Trees);
+        Assert.Empty(tile.WaterAreas);
+        Assert.Null(tile.DemDsm);
+        Assert.Null(tile.BuildingsRoads);
+        Assert.Null(tile.TerrainType);
+    }
+}

--- a/TerrainEngine/TerrainEngine.sln
+++ b/TerrainEngine/TerrainEngine.sln
@@ -7,6 +7,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TileBuilders", "TileBuilder
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "Common\Common.csproj", "{E15E491A-E872-91D8-DF7A-CA59C792F064}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common.Tests", "Common.Tests\Common.Tests.csproj", "{4B9F6F8A-DBF9-4919-A129-B3727448B616}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TileBuilders.Tests", "TileBuilders.Tests\TileBuilders.Tests.csproj", "{CEFA29D7-5B40-4AA9-918C-59D4B70F0B7C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +45,30 @@ Global
 		{E15E491A-E872-91D8-DF7A-CA59C792F064}.Release|x64.Build.0 = Release|Any CPU
 		{E15E491A-E872-91D8-DF7A-CA59C792F064}.Release|x86.ActiveCfg = Release|Any CPU
 		{E15E491A-E872-91D8-DF7A-CA59C792F064}.Release|x86.Build.0 = Release|Any CPU
+		{4B9F6F8A-DBF9-4919-A129-B3727448B616}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4B9F6F8A-DBF9-4919-A129-B3727448B616}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4B9F6F8A-DBF9-4919-A129-B3727448B616}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4B9F6F8A-DBF9-4919-A129-B3727448B616}.Debug|x64.Build.0 = Debug|Any CPU
+		{4B9F6F8A-DBF9-4919-A129-B3727448B616}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4B9F6F8A-DBF9-4919-A129-B3727448B616}.Debug|x86.Build.0 = Debug|Any CPU
+		{4B9F6F8A-DBF9-4919-A129-B3727448B616}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4B9F6F8A-DBF9-4919-A129-B3727448B616}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4B9F6F8A-DBF9-4919-A129-B3727448B616}.Release|x64.ActiveCfg = Release|Any CPU
+		{4B9F6F8A-DBF9-4919-A129-B3727448B616}.Release|x64.Build.0 = Release|Any CPU
+		{4B9F6F8A-DBF9-4919-A129-B3727448B616}.Release|x86.ActiveCfg = Release|Any CPU
+		{4B9F6F8A-DBF9-4919-A129-B3727448B616}.Release|x86.Build.0 = Release|Any CPU
+		{CEFA29D7-5B40-4AA9-918C-59D4B70F0B7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CEFA29D7-5B40-4AA9-918C-59D4B70F0B7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CEFA29D7-5B40-4AA9-918C-59D4B70F0B7C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CEFA29D7-5B40-4AA9-918C-59D4B70F0B7C}.Debug|x64.Build.0 = Debug|Any CPU
+		{CEFA29D7-5B40-4AA9-918C-59D4B70F0B7C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CEFA29D7-5B40-4AA9-918C-59D4B70F0B7C}.Debug|x86.Build.0 = Debug|Any CPU
+		{CEFA29D7-5B40-4AA9-918C-59D4B70F0B7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CEFA29D7-5B40-4AA9-918C-59D4B70F0B7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CEFA29D7-5B40-4AA9-918C-59D4B70F0B7C}.Release|x64.ActiveCfg = Release|Any CPU
+		{CEFA29D7-5B40-4AA9-918C-59D4B70F0B7C}.Release|x64.Build.0 = Release|Any CPU
+		{CEFA29D7-5B40-4AA9-918C-59D4B70F0B7C}.Release|x86.ActiveCfg = Release|Any CPU
+		{CEFA29D7-5B40-4AA9-918C-59D4B70F0B7C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TerrainEngine/TileBuilders.Tests/BuilderTests.cs
+++ b/TerrainEngine/TileBuilders.Tests/BuilderTests.cs
@@ -1,0 +1,34 @@
+using Kuoste.TerrainEngine.TileBuilders.Tests.Helpers;
+using System.Threading;
+using Xunit;
+
+namespace Kuoste.TerrainEngine.TileBuilders.Tests;
+
+public class BuilderTests
+{
+    private sealed class ConcreteBuilder : Builder { }
+
+    [Fact]
+    public void IsCancellationRequested_WithDefaultToken_ReturnsFalse()
+    {
+        var builder = new ConcreteBuilder { CancellationToken = default, Logger = NullLogger.Instance };
+        Assert.False(builder.IsCancellationRequested());
+    }
+
+    [Fact]
+    public void IsCancellationRequested_WithNonCancelledToken_ReturnsFalse()
+    {
+        using var cts = new CancellationTokenSource();
+        var builder = new ConcreteBuilder { CancellationToken = cts.Token, Logger = NullLogger.Instance };
+        Assert.False(builder.IsCancellationRequested());
+    }
+
+    [Fact]
+    public void IsCancellationRequested_WithCancelledToken_ReturnsTrue()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var builder = new ConcreteBuilder { CancellationToken = cts.Token, Logger = NullLogger.Instance };
+        Assert.True(builder.IsCancellationRequested());
+    }
+}

--- a/TerrainEngine/TileBuilders.Tests/Buildings/BuildingsCreatorTests.cs
+++ b/TerrainEngine/TileBuilders.Tests/Buildings/BuildingsCreatorTests.cs
@@ -1,0 +1,72 @@
+using Kuoste.TerrainEngine.Common.Interfaces;
+using Kuoste.TerrainEngine.Common.Tiles;
+using Kuoste.TerrainEngine.TileBuilders.Buildings;
+using Kuoste.TerrainEngine.TileBuilders.Tests.Helpers;
+using System;
+using System.IO;
+using System.Threading;
+using Xunit;
+
+namespace Kuoste.TerrainEngine.TileBuilders.Tests.Buildings;
+
+[Collection("NlsIntegration")]
+public class BuildingsCreatorTests : IDisposable
+{
+    private readonly NlsDataFixture _nls;
+    private readonly string _tempDir;
+
+    public BuildingsCreatorTests(NlsDataFixture nls)
+    {
+        _nls = nls;
+        _tempDir = Path.Combine(Path.GetTempPath(), "TerrainTileTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Build_WithShapefile_ReturnsBuildings()
+    {
+        if (_nls.DemDsm == null) return;
+
+        var result = MakeCreator().Build(MakeTile());
+
+        // The Helsinki sample area contains residential and commercial buildings
+        Assert.NotEmpty(result);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Build_WithShapefile_WritesIntermediateFile()
+    {
+        if (_nls.DemDsm == null) return;
+
+        MakeCreator().Build(MakeTile());
+
+        var expectedFile = Path.Combine(_tempDir,
+            IBuildingsBuilder.Filename(SampleDataHelper.TileName, SampleDataHelper.Version));
+        Assert.True(File.Exists(expectedFile), $"Expected intermediate file: {expectedFile}");
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Build_Buildings_HaveNonZeroVertices()
+    {
+        if (_nls.DemDsm == null) return;
+
+        var result = MakeCreator().Build(MakeTile());
+
+        Assert.All(result, b => Assert.True(b.Vertices.Length > 0));
+    }
+
+    private BuildingsCreator MakeCreator() =>
+        new() { CancellationToken = CancellationToken.None, Logger = NullLogger.Instance };
+
+    private Tile MakeTile() => new()
+    {
+        Name = SampleDataHelper.TileName,
+        Common = new TileCommon(256, _tempDir, _nls.NlsDataPath!, SampleDataHelper.Version),
+        DemDsm = _nls.DemDsm
+    };
+}

--- a/TerrainEngine/TileBuilders.Tests/Buildings/BuildingsReaderTests.cs
+++ b/TerrainEngine/TileBuilders.Tests/Buildings/BuildingsReaderTests.cs
@@ -1,0 +1,90 @@
+using Kuoste.TerrainEngine.Common.Interfaces;
+using Kuoste.TerrainEngine.Common.Tiles;
+using Kuoste.TerrainEngine.TileBuilders.Buildings;
+using Kuoste.TerrainEngine.TileBuilders.Tests.Helpers;
+using System;
+using System.IO;
+using System.Threading;
+using Xunit;
+
+namespace Kuoste.TerrainEngine.TileBuilders.Tests.Buildings;
+
+public class BuildingsReaderTests : IDisposable
+{
+    // Tile L4133B3_4 decodes to bounds [384000, 385000] x [6672000, 6673000]
+    private const string TileName = "L4133B3_4";
+    private const string Version = "1";
+
+    // One building: 1 roof triangle + 1 wall segment.
+    // All coordinates are in absolute ETRS-TM35FIN metres.
+    private const string OneBuilding =
+        "GeometryCollection " +
+        "Polygon [384001,6672001,10] [384002,6672001,10] [384001,6672002,10] [384001,6672001,10] " +
+        "Polygon [384001,6672001,10] [384002,6672001,10]";
+
+    private readonly string _tempDir;
+
+    public BuildingsReaderTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "TerrainTileTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    [Fact]
+    public void Build_WhenCancelled_ReturnsEmptyList()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var result = MakeReader(cts.Token).Build(MakeTile());
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Build_WithOneBuilding_ReturnsSingleBuilding()
+    {
+        WriteFixture(OneBuilding);
+
+        var result = MakeReader(CancellationToken.None).Build(MakeTile());
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void Build_WithOneBuilding_RoofVerticesAreRelativeToTileOrigin()
+    {
+        WriteFixture(OneBuilding);
+
+        var b = MakeReader(CancellationToken.None).Build(MakeTile())[0];
+
+        // Roof: (384001 - 384000, 6672001 - 6672000) = (1, 1)
+        Assert.Equal(1.0f, b.Vertices[0].X);
+        Assert.Equal(1.0f, b.Vertices[0].Y);
+        Assert.Equal(10.0f, b.Vertices[0].Z);
+    }
+
+    [Fact]
+    public void Build_WithOneBuilding_SubmeshSeparatorIsAfterRoofTriangles()
+    {
+        WriteFixture(OneBuilding);
+
+        var b = MakeReader(CancellationToken.None).Build(MakeTile())[0];
+
+        // 1 roof triangle → 3 indices before walls begin
+        Assert.Equal(3, b.iSubmeshSeparator);
+    }
+
+    private void WriteFixture(string content) =>
+        File.WriteAllText(
+            Path.Combine(_tempDir, IBuildingsBuilder.Filename(TileName, Version)),
+            content);
+
+    private BuildingsReader MakeReader(CancellationToken ct) =>
+        new() { CancellationToken = ct, Logger = NullLogger.Instance };
+
+    private Tile MakeTile() =>
+        new() { Name = TileName, Common = new TileCommon(256, _tempDir, _tempDir, Version) };
+}

--- a/TerrainEngine/TileBuilders.Tests/DemDsm/DemDsmCreatorTests.cs
+++ b/TerrainEngine/TileBuilders.Tests/DemDsm/DemDsmCreatorTests.cs
@@ -1,0 +1,81 @@
+using Kuoste.TerrainEngine.Common.Interfaces;
+using Kuoste.TerrainEngine.Common.Tiles;
+using Kuoste.TerrainEngine.TileBuilders.DemDsm;
+using Kuoste.TerrainEngine.TileBuilders.Tests.Helpers;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Xunit;
+
+namespace Kuoste.TerrainEngine.TileBuilders.Tests.DemDsm;
+
+public class DemDsmCreatorTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public DemDsmCreatorTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "TerrainTileTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Build_WithLazFile_ReturnsDemWithValues()
+    {
+        var dataPath = SampleDataHelper.FindNlsDataPath();
+        if (dataPath == null) return;
+
+        var creator = new DemDsmCreator { CancellationToken = CancellationToken.None, Logger = NullLogger.Instance };
+        var result = creator.Build(MakeTile(dataPath));
+
+        Assert.NotNull(result.Dem);
+
+        // At least some cells should have valid elevation data
+        int nonNanCount = 0;
+        foreach (float v in result.Dem)
+            if (!float.IsNaN(v)) nonNanCount++;
+        Assert.True(nonNanCount > 0, "Expected non-NaN DEM values in Helsinki tile");
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Build_WithLazFile_WritesIntermediateFile()
+    {
+        var dataPath = SampleDataHelper.FindNlsDataPath();
+        if (dataPath == null) return;
+
+        var creator = new DemDsmCreator { CancellationToken = CancellationToken.None, Logger = NullLogger.Instance };
+        creator.Build(MakeTile(dataPath));
+
+        var expectedFile = Path.Combine(_tempDir, IDemDsmBuilder.Filename(SampleDataHelper.TileName, SampleDataHelper.Version));
+        Assert.True(File.Exists(expectedFile), $"Expected intermediate file: {expectedFile}");
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Build_WhenIntermediateFileAlreadyExists_ReadsFromCache()
+    {
+        var dataPath = SampleDataHelper.FindNlsDataPath();
+        if (dataPath == null) return;
+
+        // First pass: create from LAZ
+        var creator1 = new DemDsmCreator { CancellationToken = CancellationToken.None, Logger = NullLogger.Instance };
+        creator1.Build(MakeTile(dataPath));
+
+        // Second pass: a fresh Creator instance should read from cache
+        var creator2 = new DemDsmCreator { CancellationToken = CancellationToken.None, Logger = NullLogger.Instance };
+        var result = creator2.Build(MakeTile(dataPath));
+
+        Assert.NotNull(result.Dem);
+    }
+
+    private Tile MakeTile(string dataPath) => new()
+    {
+        Name = SampleDataHelper.TileName,
+        Common = new TileCommon(256, _tempDir, dataPath, SampleDataHelper.Version)
+    };
+}

--- a/TerrainEngine/TileBuilders.Tests/DemDsm/DemDsmReaderTests.cs
+++ b/TerrainEngine/TileBuilders.Tests/DemDsm/DemDsmReaderTests.cs
@@ -1,0 +1,61 @@
+using Kuoste.TerrainEngine.Common.Interfaces;
+using Kuoste.TerrainEngine.Common.Tiles;
+using Kuoste.TerrainEngine.TileBuilders.DemDsm;
+using Kuoste.TerrainEngine.TileBuilders.Tests.Helpers;
+using LasUtility.VoxelGrid;
+using NetTopologySuite.Geometries;
+using System;
+using System.IO;
+using System.Threading;
+using Xunit;
+
+namespace Kuoste.TerrainEngine.TileBuilders.Tests.DemDsm;
+
+public class DemDsmReaderTests : IDisposable
+{
+    // Tile L4133B3_4 decodes to bounds [384000, 385000] x [6672000, 6673000]
+    private const string TileName = "L4133B3_4";
+    private const string Version = "1";
+
+    private readonly string _tempDir;
+
+    public DemDsmReaderTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "TerrainTileTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    [Fact]
+    public void Build_WhenCancelled_ReturnsEmptyVoxelGrid()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var reader = MakeReader(cts.Token);
+        var result = reader.Build(MakeTile());
+
+        Assert.Null(result.Dem);
+    }
+
+    [Fact]
+    public void Build_WithSerializedGrid_ReturnsDeserializedGrid()
+    {
+        var grid = VoxelGrid.CreateGrid(4, 4, new Envelope(384000, 385000, 6672000, 6673000));
+        var filePath = Path.Combine(_tempDir, IDemDsmBuilder.Filename(TileName, Version));
+        grid.Serialize(filePath);
+
+        var result = MakeReader(CancellationToken.None).Build(MakeTile());
+
+        Assert.NotNull(result.Dem);
+        Assert.Equal(4, result.Dem.GetLength(0));
+        Assert.Equal(4, result.Dem.GetLength(1));
+    }
+
+    private DemDsmReader MakeReader(CancellationToken ct) =>
+        new() { CancellationToken = ct, Logger = NullLogger.Instance };
+
+    private Tile MakeTile() =>
+        new() { Name = TileName, Common = new TileCommon(256, _tempDir, _tempDir, Version) };
+}

--- a/TerrainEngine/TileBuilders.Tests/Helpers/NlsDataFixture.cs
+++ b/TerrainEngine/TileBuilders.Tests/Helpers/NlsDataFixture.cs
@@ -1,0 +1,61 @@
+using Kuoste.TerrainEngine.Common.Tiles;
+using Kuoste.TerrainEngine.TileBuilders.DemDsm;
+using LasUtility.VoxelGrid;
+using System;
+using System.IO;
+using System.Threading;
+using Xunit;
+
+namespace Kuoste.TerrainEngine.TileBuilders.Tests.Helpers;
+
+/// <summary>
+/// xUnit collection fixture that runs DemDsmCreator once against the NLS sample data
+/// and shares the resulting VoxelGrid across all tests in the NlsIntegration collection.
+/// </summary>
+public sealed class NlsDataFixture : IDisposable
+{
+    public string? NlsDataPath { get; }
+
+    /// <summary>Shared temp directory used for the DemDsm intermediate file.</summary>
+    public string TempDir { get; }
+
+    /// <summary>
+    /// DemDsm for tile <see cref="SampleDataHelper.TileName"/>, or null when NLS data
+    /// is not available (e.g. on a CI agent without the full repo).
+    /// </summary>
+    public VoxelGrid? DemDsm { get; }
+
+    public NlsDataFixture()
+    {
+        NlsDataPath = SampleDataHelper.FindNlsDataPath();
+
+        TempDir = Path.Combine(Path.GetTempPath(), "TerrainTileTests_NlsFixture_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(TempDir);
+
+        if (NlsDataPath == null)
+            return;
+
+        var tile = new Tile
+        {
+            Name = SampleDataHelper.TileName,
+            Common = new TileCommon(256, TempDir, NlsDataPath, SampleDataHelper.Version)
+        };
+
+        var creator = new DemDsmCreator
+        {
+            CancellationToken = CancellationToken.None,
+            Logger = NullLogger.Instance
+        };
+
+        DemDsm = creator.Build(tile);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(TempDir))
+            Directory.Delete(TempDir, recursive: true);
+    }
+}
+
+[CollectionDefinition("NlsIntegration")]
+public class NlsIntegrationCollection : ICollectionFixture<NlsDataFixture> { }

--- a/TerrainEngine/TileBuilders.Tests/Helpers/NullLogger.cs
+++ b/TerrainEngine/TileBuilders.Tests/Helpers/NullLogger.cs
@@ -1,0 +1,15 @@
+using Kuoste.TerrainEngine.Common.Interfaces;
+using System;
+
+namespace Kuoste.TerrainEngine.TileBuilders.Tests.Helpers;
+
+internal sealed class NullLogger : ILogger
+{
+    public static readonly NullLogger Instance = new();
+
+    public void LogDebug(string message) { }
+    public void LogInfo(string message) { }
+    public void LogWarning(string message) { }
+    public void LogError(string message) { }
+    public void LogException(Exception exception) { }
+}

--- a/TerrainEngine/TileBuilders.Tests/Helpers/SampleDataHelper.cs
+++ b/TerrainEngine/TileBuilders.Tests/Helpers/SampleDataHelper.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+
+namespace Kuoste.TerrainEngine.TileBuilders.Tests.Helpers;
+
+internal static class SampleDataHelper
+{
+    // Tile L4133B1_5 is the centre 1km sub-tile of the L4133B1 3km point cloud,
+    // and lies within the L4133L 12km topographic-db coverage area.
+    internal const string TileName = "L4133B1_5";
+    internal const string Version = "1";
+
+    // L4133B1_5 = east-centre, north-centre sub-tile → [381000,382000] × [6673000,6674000]
+    internal const int TileMinEast = 381000;
+    internal const int TileMinNorth = 6673000;
+
+    private static readonly string NlsRelativePath = Path.Combine(
+        "fi.kuoste.terraintile", "Samples", "Helsinki9km2", "DataNlsFinland");
+
+    /// <summary>
+    /// Walks up from the test assembly directory until it finds the NLS sample-data folder.
+    /// Returns null when run without the full repo (CI without LFS data, etc.).
+    /// </summary>
+    internal static string? FindNlsDataPath()
+    {
+        var dir = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir.FullName, NlsRelativePath);
+            if (Directory.Exists(candidate))
+                return candidate;
+            dir = dir.Parent;
+        }
+        return null;
+    }
+}

--- a/TerrainEngine/TileBuilders.Tests/Rasters/RasterCreatorTests.cs
+++ b/TerrainEngine/TileBuilders.Tests/Rasters/RasterCreatorTests.cs
@@ -1,0 +1,138 @@
+using Kuoste.TerrainEngine.Common.Interfaces;
+using Kuoste.TerrainEngine.Common.Tiles;
+using Kuoste.TerrainEngine.TileBuilders.Rasters;
+using Kuoste.TerrainEngine.TileBuilders.Tests.Helpers;
+using LasUtility.Common;
+using LasUtility.Nls;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using Xunit;
+
+namespace Kuoste.TerrainEngine.TileBuilders.Tests.Rasters;
+
+public class RasterCreatorTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public RasterCreatorTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "TerrainTileTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Build_TerrainType_WritesIntermediateFile()
+    {
+        var dataPath = SampleDataHelper.FindNlsDataPath();
+        if (dataPath == null) return;
+
+        var creator = MakeTerrainTypeCreator();
+        creator.Build(MakeTile(dataPath));
+
+        var expectedFile = Path.Combine(_tempDir,
+            IRasterBuilder.Filename(SampleDataHelper.TileName, IRasterBuilder.SpecifierTerrainType, SampleDataHelper.Version));
+        Assert.True(File.Exists(expectedFile), $"Expected intermediate file: {expectedFile}");
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Build_TerrainType_ReturnsPopulatedRaster()
+    {
+        var dataPath = SampleDataHelper.FindNlsDataPath();
+        if (dataPath == null) return;
+
+        var result = (ByteRaster)MakeTerrainTypeCreator().Build(MakeTile(dataPath));
+
+        Assert.NotNull(result.Raster);
+
+        // At least some non-zero (classified) pixels expected in the Helsinki area
+        int nonZeroCount = 0;
+        foreach (var row in result.Raster)
+            foreach (byte v in row)
+                if (v != ByteRaster.NoDataValue) nonZeroCount++;
+        Assert.True(nonZeroCount > 0, "Expected some non-zero terrain type values");
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Build_BuildingsRoads_WritesIntermediateFile()
+    {
+        var dataPath = SampleDataHelper.FindNlsDataPath();
+        if (dataPath == null) return;
+
+        var creator = MakeBuildingsRoadsCreator();
+        creator.Build(MakeTile(dataPath));
+
+        var expectedFile = Path.Combine(_tempDir,
+            IRasterBuilder.Filename(SampleDataHelper.TileName, IRasterBuilder.SpecifierBuildingsRoads, SampleDataHelper.Version));
+        Assert.True(File.Exists(expectedFile), $"Expected intermediate file: {expectedFile}");
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Build_BuildingsRoads_ReturnsPopulatedRaster()
+    {
+        var dataPath = SampleDataHelper.FindNlsDataPath();
+        if (dataPath == null) return;
+
+        var result = (ByteRaster)MakeBuildingsRoadsCreator().Build(MakeTile(dataPath));
+
+        Assert.NotNull(result.Raster);
+
+        int nonZeroCount = 0;
+        foreach (var row in result.Raster)
+            foreach (byte v in row)
+                if (v != ByteRaster.NoDataValue) nonZeroCount++;
+        Assert.True(nonZeroCount > 0, "Expected some non-zero buildings/roads values");
+    }
+
+    private RasterCreator MakeTerrainTypeCreator()
+    {
+        var c = new RasterCreator { CancellationToken = CancellationToken.None, Logger = NullLogger.Instance };
+        c.SetRasterSpecifier(IRasterBuilder.SpecifierTerrainType);
+
+        var classes = new Dictionary<int, byte>();
+        foreach (var kv in TopographicDb.WaterPolygonClassesToRasterValues) classes[kv.Key] = kv.Value;
+        foreach (var kv in TopographicDb.SwampPolygonClassesToRasterValues) classes[kv.Key] = kv.Value;
+        foreach (var kv in TopographicDb.RockPolygonClassesToRasterValues) classes[kv.Key] = kv.Value;
+        foreach (var kv in TopographicDb.SandPolygonClassesToRasterValues) classes[kv.Key] = kv.Value;
+        foreach (var kv in TopographicDb.FieldPolygonClassesToRasterValues) classes[kv.Key] = kv.Value;
+        foreach (var kv in TopographicDb.RockLineClassesToRasterValues) classes[kv.Key] = kv.Value;
+        c.SetRasterizedClassesWithRasterValues(classes);
+
+        c.SetShpFilenames(new[]
+        {
+            TopographicDb.sPrefixForTerrainType + "L4133L" + TopographicDb.sPostfixForPolygon + ".shp"
+        });
+        return c;
+    }
+
+    private RasterCreator MakeBuildingsRoadsCreator()
+    {
+        var c = new RasterCreator { CancellationToken = CancellationToken.None, Logger = NullLogger.Instance };
+        c.SetRasterSpecifier(IRasterBuilder.SpecifierBuildingsRoads);
+
+        var classes = new Dictionary<int, byte>();
+        foreach (var kv in TopographicDb.RoadLineClassesToRasterValues) classes[kv.Key] = kv.Value;
+        foreach (var kv in TopographicDb.BuildingPolygonClassesToRasterValues) classes[kv.Key] = kv.Value;
+        c.SetRasterizedClassesWithRasterValues(classes);
+
+        c.SetShpFilenames(new[]
+        {
+            TopographicDb.sPrefixForRoads + "L4133L" + TopographicDb.sPostfixForLine + ".shp",
+            TopographicDb.sPrefixForBuildings + "L4133L" + TopographicDb.sPostfixForPolygon + ".shp"
+        });
+        return c;
+    }
+
+    private Tile MakeTile(string dataPath) => new()
+    {
+        Name = SampleDataHelper.TileName,
+        Common = new TileCommon(256, _tempDir, dataPath, SampleDataHelper.Version)
+    };
+}

--- a/TerrainEngine/TileBuilders.Tests/Rasters/RasterReaderTests.cs
+++ b/TerrainEngine/TileBuilders.Tests/Rasters/RasterReaderTests.cs
@@ -1,0 +1,78 @@
+using Kuoste.TerrainEngine.Common.Interfaces;
+using Kuoste.TerrainEngine.Common.Tiles;
+using Kuoste.TerrainEngine.TileBuilders.Rasters;
+using Kuoste.TerrainEngine.TileBuilders.Tests.Helpers;
+using LasUtility.Common;
+using NetTopologySuite.Geometries;
+using System;
+using System.IO;
+using System.Threading;
+using Xunit;
+
+namespace Kuoste.TerrainEngine.TileBuilders.Tests.Rasters;
+
+public class RasterReaderTests : IDisposable
+{
+    private const string TileName = "L4133B3_4";
+    private const string Version = "1";
+    private const string Specifier = "terraintype";
+
+    private readonly string _tempDir;
+
+    public RasterReaderTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "TerrainTileTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    [Fact]
+    public void Build_WhenCancelled_ReturnsEmptyRaster()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var result = MakeReader(cts.Token).Build(MakeTile());
+
+        Assert.IsType<ByteRaster>(result);
+        Assert.Null(((ByteRaster)result).Raster);
+    }
+
+    [Fact]
+    public void Build_WithSerializedRaster_ReturnsCorrectDimensions()
+    {
+        var raster = new ByteRaster();
+        raster.InitializeRaster(3, 4, new Envelope(384000, 385000, 6672000, 6673000));
+        raster.Raster[0][0] = 42;
+        raster.WriteAsAscii(Path.Combine(_tempDir, IRasterBuilder.Filename(TileName, Specifier, Version)));
+
+        var result = (ByteRaster)MakeReader(CancellationToken.None).Build(MakeTile());
+
+        Assert.Equal(3, result.Raster.Length);
+        Assert.Equal(4, result.Raster[0].Length);
+    }
+
+    [Fact]
+    public void Build_WithSerializedRaster_PreservesValues()
+    {
+        var raster = new ByteRaster();
+        raster.InitializeRaster(3, 4, new Envelope(384000, 385000, 6672000, 6673000));
+        raster.Raster[0][0] = 42;
+        raster.WriteAsAscii(Path.Combine(_tempDir, IRasterBuilder.Filename(TileName, Specifier, Version)));
+
+        var result = (ByteRaster)MakeReader(CancellationToken.None).Build(MakeTile());
+
+        Assert.Equal(42, result.Raster[0][0]);
+    }
+
+    private RasterReader MakeReader(CancellationToken ct)
+    {
+        var r = new RasterReader { CancellationToken = ct, Logger = NullLogger.Instance };
+        r.SetRasterSpecifier(Specifier);
+        return r;
+    }
+
+    private Tile MakeTile() =>
+        new() { Name = TileName, Common = new TileCommon(256, _tempDir, _tempDir, Version) };
+}

--- a/TerrainEngine/TileBuilders.Tests/TileBuilders.Tests.csproj
+++ b/TerrainEngine/TileBuilders.Tests/TileBuilders.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TileBuilders\TileBuilders.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TerrainEngine/TileBuilders.Tests/Trees/SimpleTreeCreatorTests.cs
+++ b/TerrainEngine/TileBuilders.Tests/Trees/SimpleTreeCreatorTests.cs
@@ -1,0 +1,180 @@
+using Kuoste.TerrainEngine.Common.Interfaces;
+using Kuoste.TerrainEngine.Common.Tiles;
+using Kuoste.TerrainEngine.TileBuilders.Tests.Helpers;
+using Kuoste.TerrainEngine.TileBuilders.Trees;
+using LasUtility.Common;
+using LasUtility.Nls;
+using LasUtility.VoxelGrid;
+using NetTopologySuite.Geometries;
+using System;
+using System.IO;
+using System.Threading;
+using Xunit;
+
+namespace Kuoste.TerrainEngine.TileBuilders.Tests.Trees;
+
+public class SimpleTreeCreatorTests : IDisposable
+{
+    // L4133B1_5 = [381000,382000] × [6673000,6674000]
+    private const string TileName = "L4133B1_5";
+    private const int MinEast = SampleDataHelper.TileMinEast;
+    private const int MinNorth = SampleDataHelper.TileMinNorth;
+
+    // The grid is made 10 % larger than the tile on all four sides to mirror production,
+    // where the DemDsm always has overlap. This keeps tile bounds strictly interior to
+    // the grid so ProjToCell never hits the exclusive-max boundary.
+    private const int OverlapMeters = 50;
+    private const int GridEdgeMeters = TileCommon.EdgeLength + 2 * OverlapMeters; // 1100 m
+    private const int GridSize = 110;  // 10 m/cell
+    // Tree is placed at the grid cell that maps to the tile centre
+    private const int CenterRow = GridSize / 2; // 55
+    private const int CenterCol = GridSize / 2; // 55
+
+    private const float GroundHeight = 50.0f;
+    private const float VegHeight = 65.0f;   // 15 m above ground → IsHighVegetation ✓
+
+    private readonly string _tempDir;
+
+    public SimpleTreeCreatorTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "TerrainTileTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    [Fact]
+    public void Build_WhenCancelled_ReturnsEmptyList()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var (tile, _) = CreateSyntheticTile();
+        var result = MakeCreator(cts.Token).Build(tile);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Build_WithNoVegetationPoints_ReturnsNoTrees()
+    {
+        var (tile, _) = CreateSyntheticTile();
+
+        var result = MakeCreator(CancellationToken.None).Build(tile);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Build_WithInsufficientNeighbourhoodVegetation_ReturnsNoTrees()
+    {
+        var (tile, grid) = CreateSyntheticTile();
+
+        // Add only 3 high-vegetation points in the same cell — fewer than the required 5
+        grid.GetGridCoordinates(CenterRow, CenterCol, out double cx, out double cy);
+        for (int i = 0; i < 3; i++)
+            grid.AddPoint(cx + 1, cy + 1, VegHeight, (byte)PointCloud05p.Classes.HighVegetation, false);
+
+        grid.SortAndTrim();
+
+        var result = MakeCreator(CancellationToken.None).Build(tile);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Build_WithEnoughHighVegetation_ReturnsTree()
+    {
+        var (tile, grid) = CreateSyntheticTile();
+        AddTreeAtCell(grid, CenterRow, CenterCol);
+
+        var result = MakeCreator(CancellationToken.None).Build(tile);
+
+        Assert.NotEmpty(result);
+    }
+
+    [Fact]
+    public void Build_TreePosition_IsNormalisedToTileFraction()
+    {
+        var (tile, grid) = CreateSyntheticTile();
+        AddTreeAtCell(grid, CenterRow, CenterCol);
+
+        var result = MakeCreator(CancellationToken.None).Build(tile);
+
+        Assert.Single(result);
+        // Coordinates are (x - MinEast) / EdgeLength  →  must be in [0, 1]
+        Assert.InRange(result[0].X, 0.0, 1.0);
+        Assert.InRange(result[0].Y, 0.0, 1.0);
+    }
+
+    [Fact]
+    public void Build_WritesIntermediateGeojsonFile()
+    {
+        var (tile, grid) = CreateSyntheticTile();
+        AddTreeAtCell(grid, CenterRow, CenterCol);
+
+        MakeCreator(CancellationToken.None).Build(tile);
+
+        var expectedFile = Path.Combine(_tempDir, ITreeBuilder.Filename(TileName, SampleDataHelper.Version));
+        Assert.True(File.Exists(expectedFile));
+    }
+
+    // ---- helpers ----
+
+    private (Tile tile, VoxelGrid grid) CreateSyntheticTile()
+    {
+        // Extend beyond the tile on all sides so tile bounds are strictly interior
+        var extent = new Envelope(
+            MinEast - OverlapMeters, MinEast + TileCommon.EdgeLength + OverlapMeters,
+            MinNorth - OverlapMeters, MinNorth + TileCommon.EdgeLength + OverlapMeters);
+
+        var grid = VoxelGrid.CreateGrid(GridSize, GridSize, extent);
+
+        // Fill in ground heights so GetValue(row,col) never returns NaN
+        for (int r = 0; r < GridSize; r++)
+            for (int c = 0; c < GridSize; c++)
+                grid.Dem[r, c] = GroundHeight;
+
+        var raster = new ByteRaster();
+        raster.InitializeRaster(GridSize, GridSize, extent);
+
+        var tile = new Tile
+        {
+            Name = TileName,
+            Common = new TileCommon(256, _tempDir, _tempDir, SampleDataHelper.Version),
+            DemDsm = grid,
+            BuildingsRoads = raster
+        };
+
+        return (tile, grid);
+    }
+
+    /// <summary>
+    /// Places a dominant tree at (centerRow, centerCol) with enough neighbourhood
+    /// vegetation to satisfy SimpleTreeCreator's threshold of 5 high-vegetation points.
+    /// </summary>
+    private static void AddTreeAtCell(VoxelGrid grid, int centerRow, int centerCol)
+    {
+        const byte highVeg = (byte)PointCloud05p.Classes.HighVegetation;
+
+        // Center cell: highest point in neighbourhood
+        grid.GetGridCoordinates(centerRow, centerCol, out double cx, out double cy);
+        grid.AddPoint(cx + 1, cy + 1, VegHeight, highVeg, false);
+
+        // 8 adjacent cells at slightly lower height → total 9 points ≥ 5 required
+        for (int dr = -1; dr <= 1; dr++)
+        {
+            for (int dc = -1; dc <= 1; dc++)
+            {
+                if (dr == 0 && dc == 0) continue;
+                grid.GetGridCoordinates(centerRow + dr, centerCol + dc, out double nx, out double ny);
+                grid.AddPoint(nx + 1, ny + 1, VegHeight - 2.0f, highVeg, false);
+            }
+        }
+
+        grid.SortAndTrim();
+    }
+
+    private SimpleTreeCreator MakeCreator(CancellationToken ct) =>
+        new() { CancellationToken = ct, Logger = NullLogger.Instance };
+}

--- a/TerrainEngine/TileBuilders.Tests/Trees/TreeReaderTests.cs
+++ b/TerrainEngine/TileBuilders.Tests/Trees/TreeReaderTests.cs
@@ -1,0 +1,86 @@
+using Kuoste.TerrainEngine.Common.Interfaces;
+using Kuoste.TerrainEngine.Common.Tiles;
+using Kuoste.TerrainEngine.TileBuilders.Tests.Helpers;
+using Kuoste.TerrainEngine.TileBuilders.Trees;
+using System;
+using System.IO;
+using System.Threading;
+using Xunit;
+
+namespace Kuoste.TerrainEngine.TileBuilders.Tests.Trees;
+
+public class TreeReaderTests : IDisposable
+{
+    // Tile L4133B3_4 decodes to bounds [384000, 385000] x [6672000, 6673000]
+    private const string TileName = "L4133B3_4";
+    private const string Version = "1";
+
+    // Two trees at absolute coordinates; EdgeLength = 1000
+    private const string TwoTrees =
+        "Point [384500,6672500,15] Point [384600,6672600,20]";
+
+    private readonly string _tempDir;
+
+    public TreeReaderTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "TerrainTileTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    [Fact]
+    public void Build_WhenCancelled_ReturnsEmptyList()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var result = MakeReader(cts.Token).Build(MakeTile());
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Build_WithTwoTrees_ReturnsTwoPoints()
+    {
+        WriteFixture(TwoTrees);
+
+        var result = MakeReader(CancellationToken.None).Build(MakeTile());
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void Build_NormalizesCoordinatesRelativeToTile()
+    {
+        WriteFixture(TwoTrees);
+
+        var trees = MakeReader(CancellationToken.None).Build(MakeTile());
+
+        // (384500 - 384000) / 1000 = 0.5
+        Assert.Equal(0.5, trees[0].X, precision: 5);
+        Assert.Equal(0.5, trees[0].Y, precision: 5);
+        Assert.Equal(15.0, trees[0].Z, precision: 5);
+    }
+
+    [Fact]
+    public void Build_WithEmptyFile_ReturnsEmptyList()
+    {
+        WriteFixture(string.Empty);
+
+        var result = MakeReader(CancellationToken.None).Build(MakeTile());
+
+        Assert.Empty(result);
+    }
+
+    private void WriteFixture(string content) =>
+        File.WriteAllText(
+            Path.Combine(_tempDir, ITreeBuilder.Filename(TileName, Version)),
+            content);
+
+    private TreeReader MakeReader(CancellationToken ct) =>
+        new() { CancellationToken = ct, Logger = NullLogger.Instance };
+
+    private Tile MakeTile() =>
+        new() { Name = TileName, Common = new TileCommon(256, _tempDir, _tempDir, Version) };
+}

--- a/TerrainEngine/TileBuilders.Tests/WaterAreas/WaterAreasCreatorTests.cs
+++ b/TerrainEngine/TileBuilders.Tests/WaterAreas/WaterAreasCreatorTests.cs
@@ -1,0 +1,72 @@
+using Kuoste.TerrainEngine.Common.Interfaces;
+using Kuoste.TerrainEngine.Common.Tiles;
+using Kuoste.TerrainEngine.TileBuilders.Tests.Helpers;
+using Kuoste.TerrainEngine.TileBuilders.WaterAreas;
+using System;
+using System.IO;
+using System.Threading;
+using Xunit;
+
+namespace Kuoste.TerrainEngine.TileBuilders.Tests.WaterAreas;
+
+[Collection("NlsIntegration")]
+public class WaterAreasCreatorTests : IDisposable
+{
+    private readonly NlsDataFixture _nls;
+    private readonly string _tempDir;
+
+    public WaterAreasCreatorTests(NlsDataFixture nls)
+    {
+        _nls = nls;
+        _tempDir = Path.Combine(Path.GetTempPath(), "TerrainTileTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Build_WithShapefile_ReturnsPolygons()
+    {
+        if (_nls.DemDsm == null) return;
+
+        var result = MakeCreator().Build(MakeTile());
+
+        // The Helsinki 9km² sample covers the Espoo/Helsinki coastline — water areas expected
+        Assert.NotEmpty(result);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Build_WithShapefile_WritesIntermediateFile()
+    {
+        if (_nls.DemDsm == null) return;
+
+        MakeCreator().Build(MakeTile());
+
+        var expectedFile = Path.Combine(_tempDir,
+            IWaterAreasBuilder.Filename(SampleDataHelper.TileName, SampleDataHelper.Version));
+        Assert.True(File.Exists(expectedFile), $"Expected intermediate file: {expectedFile}");
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public void Build_WaterPolygons_AreClosedRings()
+    {
+        if (_nls.DemDsm == null) return;
+
+        var result = MakeCreator().Build(MakeTile());
+
+        Assert.All(result, p => Assert.True(p.ExteriorRing.IsClosed));
+    }
+
+    private WaterAreasCreator MakeCreator() =>
+        new() { CancellationToken = CancellationToken.None, Logger = NullLogger.Instance };
+
+    private Tile MakeTile() => new()
+    {
+        Name = SampleDataHelper.TileName,
+        Common = new TileCommon(256, _tempDir, _nls.NlsDataPath!, SampleDataHelper.Version),
+        DemDsm = _nls.DemDsm
+    };
+}

--- a/TerrainEngine/TileBuilders.Tests/WaterAreas/WaterAreasReaderTests.cs
+++ b/TerrainEngine/TileBuilders.Tests/WaterAreas/WaterAreasReaderTests.cs
@@ -1,0 +1,95 @@
+using Kuoste.TerrainEngine.Common.Interfaces;
+using Kuoste.TerrainEngine.Common.Tiles;
+using Kuoste.TerrainEngine.TileBuilders.Tests.Helpers;
+using Kuoste.TerrainEngine.TileBuilders.WaterAreas;
+using System;
+using System.IO;
+using System.Threading;
+using Xunit;
+
+namespace Kuoste.TerrainEngine.TileBuilders.Tests.WaterAreas;
+
+public class WaterAreasReaderTests : IDisposable
+{
+    private const string TileName = "L4133B3_4";
+    private const string Version = "1";
+
+    // A closed polygon with 5 coordinate entries (first = last)
+    private const string OnePolygon =
+        "Polygon " +
+        "[384100,6672100,0] [384200,6672100,0] [384200,6672200,0] [384100,6672200,0] [384100,6672100,0]";
+
+    private readonly string _tempDir;
+
+    public WaterAreasReaderTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "TerrainTileTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    [Fact]
+    public void Build_WhenCancelled_ReturnsEmptyList()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var result = MakeReader(cts.Token).Build(MakeTile());
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Build_WithOnePolygon_ReturnsSinglePolygon()
+    {
+        WriteFixture(OnePolygon);
+
+        var result = MakeReader(CancellationToken.None).Build(MakeTile());
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void Build_WithOnePolygon_HasExpectedCoordinateCount()
+    {
+        WriteFixture(OnePolygon);
+
+        var polygon = MakeReader(CancellationToken.None).Build(MakeTile())[0];
+
+        Assert.Equal(5, polygon.ExteriorRing.NumPoints);
+    }
+
+    [Fact]
+    public void Build_WithOnePolygon_CoordinatesAreAbsolute()
+    {
+        WriteFixture(OnePolygon);
+
+        var polygon = MakeReader(CancellationToken.None).Build(MakeTile())[0];
+        var first = polygon.ExteriorRing.Coordinates[0];
+
+        Assert.Equal(384100, first.X, precision: 0);
+        Assert.Equal(6672100, first.Y, precision: 0);
+    }
+
+    [Fact]
+    public void Build_WithEmptyFile_ReturnsEmptyList()
+    {
+        WriteFixture(string.Empty);
+
+        var result = MakeReader(CancellationToken.None).Build(MakeTile());
+
+        Assert.Empty(result);
+    }
+
+    private void WriteFixture(string content) =>
+        File.WriteAllText(
+            Path.Combine(_tempDir, IWaterAreasBuilder.Filename(TileName, Version)),
+            content);
+
+    private WaterAreasReader MakeReader(CancellationToken ct) =>
+        new() { CancellationToken = ct, Logger = NullLogger.Instance };
+
+    private Tile MakeTile() =>
+        new() { Name = TileName, Common = new TileCommon(256, _tempDir, _tempDir, Version) };
+}

--- a/TerrainEngine/TileBuilders/Buildings/BuildingsCreator.cs
+++ b/TerrainEngine/TileBuilders/Buildings/BuildingsCreator.cs
@@ -275,10 +275,10 @@ namespace Kuoste.TerrainEngine.TileBuilders.Buildings
             streamWriter.Write("{ \"type\":\"Polygon\", \"coordinates\": ");
             streamWriter.Write("[[");
 
-            streamWriter.Write($"[{c0.X},{c0.Y},{fBuildingHeight}],");
-            streamWriter.Write($"[{c1.X},{c1.Y},{fBuildingHeight}],");
-            streamWriter.Write($"[{c2.X},{c2.Y},{fBuildingHeight}],");
-            streamWriter.Write($"[{c0.X},{c0.Y},{fBuildingHeight}]");
+            streamWriter.Write(FormattableString.Invariant($"[{c0.X},{c0.Y},{fBuildingHeight}],"));
+            streamWriter.Write(FormattableString.Invariant($"[{c1.X},{c1.Y},{fBuildingHeight}],"));
+            streamWriter.Write(FormattableString.Invariant($"[{c2.X},{c2.Y},{fBuildingHeight}],"));
+            streamWriter.Write(FormattableString.Invariant($"[{c0.X},{c0.Y},{fBuildingHeight}]"));
 
             // End polygon
             streamWriter.Write("]]");
@@ -299,7 +299,7 @@ namespace Kuoste.TerrainEngine.TileBuilders.Buildings
                 if (double.IsNaN(dGroundHeight))
                     dGroundHeight = fLowestGroundHeight;
 
-                streamWriter.Write($"[{Math.Round(c.X, 2)},{Math.Round(c.Y, 2)},{Math.Round(dGroundHeight, 2)}]");
+                streamWriter.Write(FormattableString.Invariant($"[{Math.Round(c.X, 2)},{Math.Round(c.Y, 2)},{Math.Round(dGroundHeight, 2)}]"));
 
                 if (i < buildingExterior.Coordinates.Length - 1)
                 {

--- a/TerrainEngine/TileBuilders/Buildings/BuildingsReader.cs
+++ b/TerrainEngine/TileBuilders/Buildings/BuildingsReader.cs
@@ -4,6 +4,7 @@ using LasUtility.Nls;
 using NetTopologySuite.Geometries;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Numerics;
 
@@ -51,7 +52,10 @@ namespace Kuoste.TerrainEngine.TileBuilders.Buildings
                         // Delete the last character which is a closing bracket and everyting after it
                         sCoords[2] = sCoords[2][..sCoords[2].IndexOf(']')];
 
-                        vCoordinates.Add(new(float.Parse(sCoords[0]), float.Parse(sCoords[1]), float.Parse(sCoords[2])));
+                        vCoordinates.Add(new(
+                            float.Parse(sCoords[0], CultureInfo.InvariantCulture),
+                            float.Parse(sCoords[1], CultureInfo.InvariantCulture),
+                            float.Parse(sCoords[2], CultureInfo.InvariantCulture)));
                     }
 
                     if (vCoordinates.Count == 0)

--- a/TerrainEngine/TileBuilders/Trees/TreeReader.cs
+++ b/TerrainEngine/TileBuilders/Trees/TreeReader.cs
@@ -3,6 +3,7 @@ using Kuoste.TerrainEngine.Common.Tiles;
 using LasUtility.Nls;
 using NetTopologySuite.Geometries;
 using System;
+using System.Globalization;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -42,9 +43,9 @@ namespace Kuoste.TerrainEngine.TileBuilders.Trees
                     coords[2] = coords[2][..coords[2].IndexOf(']')];
 
                     trees.Add(new(
-                        (double.Parse(coords[0]) - bounds.MinX) / TileCommon.EdgeLength,
-                        (double.Parse(coords[1]) - bounds.MinY) / TileCommon.EdgeLength,
-                        double.Parse(coords[2])));
+                        (double.Parse(coords[0], CultureInfo.InvariantCulture) - bounds.MinX) / TileCommon.EdgeLength,
+                        (double.Parse(coords[1], CultureInfo.InvariantCulture) - bounds.MinY) / TileCommon.EdgeLength,
+                        double.Parse(coords[2], CultureInfo.InvariantCulture)));
                 }
             }
 

--- a/TerrainEngine/TileBuilders/WaterAreas/WaterAreasCreator.cs
+++ b/TerrainEngine/TileBuilders/WaterAreas/WaterAreasCreator.cs
@@ -91,7 +91,7 @@ namespace Kuoste.TerrainEngine.TileBuilders.WaterAreas
 
                             for (int i = 0; i < coords.Count; i++)
                             {
-                                streamWriter.Write($"[{coords[i].X},{coords[i].Y},{coords[i].Z}]");
+                                streamWriter.Write(FormattableString.Invariant($"[{coords[i].X},{coords[i].Y},{coords[i].Z}]"));
 
                                 if (i < coords.Count - 1)
                                 {

--- a/TerrainEngine/TileBuilders/WaterAreas/WaterAreasReader.cs
+++ b/TerrainEngine/TileBuilders/WaterAreas/WaterAreasReader.cs
@@ -3,6 +3,7 @@ using Kuoste.TerrainEngine.Common.Tiles;
 using NetTopologySuite.Geometries;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 
 namespace Kuoste.TerrainEngine.TileBuilders.WaterAreas
@@ -40,9 +41,9 @@ namespace Kuoste.TerrainEngine.TileBuilders.WaterAreas
                     coords[2] = coords[2][..coords[2].IndexOf(']')];
 
                     coordinates.Add(new(
-                        double.Parse(coords[0]),
-                        double.Parse(coords[1]),
-                        double.Parse(coords[2])));
+                        double.Parse(coords[0], CultureInfo.InvariantCulture),
+                        double.Parse(coords[1], CultureInfo.InvariantCulture),
+                        double.Parse(coords[2], CultureInfo.InvariantCulture)));
                 }
 
                 if (coordinates.Count > 0)


### PR DESCRIPTION
Adds xUnit test projects for the TerrainEngine core — the regression safety net for the upcoming triangulation/architecture refactors (see the design plan in `docs/terrain-generalization-plan.md`, landing separately).

- `Common.Tests` — `Tile`, `TileCommon`, and `IXxxBuilder.Filename` tests
- `TileBuilders.Tests` — Reader/Creator tests, including NLS-data integration tests that skip when the sample data isn't present
- Fixes a locale bug in the geojson I/O surfaced by the tests

Closes #39