### PR TITLE
Introduce ITileScheme and route TileBuilders through it

### DIFF
--- a/TerrainEngine/Common/Interfaces/ITileScheme.cs
+++ b/TerrainEngine/Common/Interfaces/ITileScheme.cs
@@ -1,0 +1,37 @@
+using NetTopologySuite.Geometries;
+using System.Collections.Generic;
+
+namespace Kuoste.TerrainEngine.Common.Interfaces
+{
+    /// <summary>
+    /// Maps between tile names and world coordinates for one tiling scheme
+    /// (NLS Finland map sheets today; a generic grid for other countries / output).
+    /// Keeps the engine independent of any single country's naming.
+    /// </summary>
+    public interface ITileScheme
+    {
+        /// <summary>Coordinate reference of this scheme's world coordinates (NLS = 3067).</summary>
+        int Epsg { get; }
+
+        /// <summary>World-coordinate bounds of a named tile.</summary>
+        Envelope Decode(string tileName);
+
+        /// <summary>Name of the tile of the given edge length that contains (x, y).</summary>
+        string Encode(double x, double y, int edgeLengthMeters);
+
+        /// <summary>Edge length in metres encoded by a tile name.</summary>
+        int EdgeLengthMeters(string tileName);
+
+        /// <summary>The (larger) tile of the given edge length that contains this tile.</summary>
+        string ParentTile(string tileName, int edgeLengthMeters);
+
+        /// <summary>Sub-tiles of the given (smaller) edge length within a tile.</summary>
+        IEnumerable<string> SubTiles(string tileName, int edgeLengthMeters);
+
+        /// <summary>All tiles of the given edge length intersecting the bounds.</summary>
+        IEnumerable<string> TilesInBounds(Envelope bounds, int edgeLengthMeters);
+
+        /// <summary>Same-size edge/corner neighbours (for halo stitching).</summary>
+        IEnumerable<string> Neighbors(string tileName);
+    }
+}

--- a/TerrainEngine/Common/Tiles/NlsTileScheme.cs
+++ b/TerrainEngine/Common/Tiles/NlsTileScheme.cs
@@ -1,0 +1,72 @@
+using Kuoste.TerrainEngine.Common.Interfaces;
+using LasUtility.Nls;
+using NetTopologySuite.Geometries;
+using System;
+using System.Collections.Generic;
+
+namespace Kuoste.TerrainEngine.Common.Tiles
+{
+    /// <summary>
+    /// <see cref="ITileScheme"/> for the National Land Survey of Finland map-sheet grid
+    /// (ETRS-TM35FIN / EPSG:3067), wrapping <see cref="TileNamer"/>.
+    /// </summary>
+    public class NlsTileScheme : ITileScheme
+    {
+        public int Epsg => 3067;
+
+        public Envelope Decode(string tileName)
+        {
+            TileNamer.Decode(tileName, out Envelope bounds);
+            return bounds;
+        }
+
+        public string Encode(double x, double y, int edgeLengthMeters)
+            => TileNamer.Encode((int)x, (int)y, edgeLengthMeters);
+
+        public int EdgeLengthMeters(string tileName)
+            => (int)Math.Round(Decode(tileName).Width);
+
+        public string ParentTile(string tileName, int edgeLengthMeters)
+        {
+            Envelope e = Decode(tileName);
+            return Encode(e.MinX, e.MinY, edgeLengthMeters);
+        }
+
+        public IEnumerable<string> SubTiles(string tileName, int edgeLengthMeters)
+            => TilesInBounds(Decode(tileName), edgeLengthMeters);
+
+        public IEnumerable<string> TilesInBounds(Envelope bounds, int edgeLengthMeters)
+        {
+            // Align the start to the grid via the tile containing the lower-left corner.
+            Envelope start = Decode(Encode(bounds.MinX, bounds.MinY, edgeLengthMeters));
+
+            for (double x = start.MinX; x < bounds.MaxX; x += edgeLengthMeters)
+            {
+                for (double y = start.MinY; y < bounds.MaxY; y += edgeLengthMeters)
+                {
+                    yield return Encode(x, y, edgeLengthMeters);
+                }
+            }
+        }
+
+        public IEnumerable<string> Neighbors(string tileName)
+        {
+            Envelope e = Decode(tileName);
+            int edge = (int)Math.Round(e.Width);
+
+            for (int dy = -1; dy <= 1; dy++)
+            {
+                for (int dx = -1; dx <= 1; dx++)
+                {
+                    if (dx == 0 && dy == 0)
+                        continue;
+
+                    // Use the neighbour tile centre to avoid boundary ambiguity.
+                    double cx = e.MinX + (dx + 0.5) * edge;
+                    double cy = e.MinY + (dy + 0.5) * edge;
+                    yield return Encode(cx, cy, edge);
+                }
+            }
+        }
+    }
+}

--- a/TerrainEngine/Common/Tiles/TileCommon.cs
+++ b/TerrainEngine/Common/Tiles/TileCommon.cs
@@ -1,3 +1,4 @@
+using Kuoste.TerrainEngine.Common.Interfaces;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -16,12 +17,16 @@ namespace Kuoste.TerrainEngine.Common.Tiles
 
         public string Version { get; }
 
-        public TileCommon(int alphamapResolution, string directoryIntermediate, string directoryOriginal, string version)
+        /// <summary>Tiling scheme that maps tile names to world coordinates. Defaults to NLS Finland.</summary>
+        public ITileScheme TileScheme { get; }
+
+        public TileCommon(int alphamapResolution, string directoryIntermediate, string directoryOriginal, string version, ITileScheme? tileScheme = null)
         {
             AlphamapResolution = alphamapResolution;
             DirectoryIntermediate = directoryIntermediate;
             DirectoryOriginal = directoryOriginal;
             Version = version;
+            TileScheme = tileScheme ?? new NlsTileScheme();
         }
     }
 }

--- a/TerrainEngine/TileBuilders/Buildings/BuildingsCreator.cs
+++ b/TerrainEngine/TileBuilders/Buildings/BuildingsCreator.cs
@@ -27,8 +27,8 @@ namespace Kuoste.TerrainEngine.TileBuilders.Buildings
                 return new();
 
             // Get topographic db tile name
-            TileNamer.Decode(tile.Name, out Envelope bounds);
-            string s12km12kmMapTileName = TileNamer.Encode((int)bounds.MinX, (int)bounds.MinY, TopographicDb.iMapTileEdgeLengthInMeters);
+            Envelope bounds = tile.Common.TileScheme.Decode(tile.Name);
+            string s12km12kmMapTileName = tile.Common.TileScheme.Encode(bounds.MinX, bounds.MinY, TopographicDb.iMapTileEdgeLengthInMeters);
 
             string sOutputFilename = Path.Combine(tile.Common.DirectoryIntermediate, IBuildingsBuilder.Filename(tile.Name, tile.Common.Version));
             string sOutputTempName = sOutputFilename + ".tmp";

--- a/TerrainEngine/TileBuilders/Buildings/BuildingsReader.cs
+++ b/TerrainEngine/TileBuilders/Buildings/BuildingsReader.cs
@@ -1,6 +1,5 @@
 using Kuoste.TerrainEngine.Common.Interfaces;
 using Kuoste.TerrainEngine.Common.Tiles;
-using LasUtility.Nls;
 using NetTopologySuite.Geometries;
 using System;
 using System.Collections.Generic;
@@ -19,7 +18,7 @@ namespace Kuoste.TerrainEngine.TileBuilders.Buildings
             if (IsCancellationRequested())
                 return buildings;
 
-            TileNamer.Decode(tile.Name, out Envelope bounds);
+            Envelope bounds = tile.Common.TileScheme.Decode(tile.Name);
             string sFullFilename = Path.Combine(tile.Common.DirectoryIntermediate, IBuildingsBuilder.Filename(tile.Name, tile.Common.Version));
 
             string[] sBuildings = File.ReadAllText(sFullFilename).Split("GeometryCollection");

--- a/TerrainEngine/TileBuilders/DemDsm/DemDsmCreator.cs
+++ b/TerrainEngine/TileBuilders/DemDsm/DemDsmCreator.cs
@@ -38,9 +38,9 @@ namespace Kuoste.TerrainEngine.TileBuilders.DemDsm
             if (IsCancellationRequested())
                 return new();
 
-            TileNamer.Decode(tile.Name, out Envelope bounds1km);
-            string s3km3kmTileName = TileNamer.Encode((int)bounds1km.MinX, (int)bounds1km.MinY, 3000);
-            TileNamer.Decode(s3km3kmTileName, out Envelope bounds3km);
+            Envelope bounds1km = tile.Common.TileScheme.Decode(tile.Name);
+            string s3km3kmTileName = tile.Common.TileScheme.Encode(bounds1km.MinX, bounds1km.MinY, 3000);
+            Envelope bounds3km = tile.Common.TileScheme.Decode(s3km3kmTileName);
 
             // Check if the tile is already being processed
             if (true == _3kmDemDsmDone.TryGetValue(s3km3kmTileName, out bool bIsCompleted))
@@ -81,7 +81,7 @@ namespace Kuoste.TerrainEngine.TileBuilders.DemDsm
             {
                 // Create the NLS (Maanmittauslaitos) style name of a 1x1 km2 tile in order to get the coordinates.
                 string sSubmeshName = s3km3kmTileName + "_" + (i + 1).ToString();
-                TileNamer.Decode(sSubmeshName, out Envelope extent);
+                Envelope extent = tile.Common.TileScheme.Decode(sSubmeshName);
 
                 extent.ExpandBy(_iOverlapInMeters);
 
@@ -245,7 +245,7 @@ namespace Kuoste.TerrainEngine.TileBuilders.DemDsm
 
                 // Use the name of a 1x1 km2 tile to get the coordinates
                 string sSubmeshName = s3km3kmTileName + "_" + (i + 1).ToString();
-                TileNamer.Decode(sSubmeshName, out Envelope env);
+                Envelope env = tile.Common.TileScheme.Decode(sSubmeshName);
 
                 SurfaceTriangulation tri = triangulations[i];
                 VoxelGrid grid = grids[i];

--- a/TerrainEngine/TileBuilders/Rasters/RasterCreator.cs
+++ b/TerrainEngine/TileBuilders/Rasters/RasterCreator.cs
@@ -30,9 +30,9 @@ namespace Kuoste.TerrainEngine.TileBuilders.Rasters
                 return new ByteRaster();
 
             // Get topographic db tile name
-            TileNamer.Decode(tile.Name, out Envelope bounds);
-            string s12km12kmMapTileName = TileNamer.Encode((int)bounds.MinX, (int)bounds.MinY, TopographicDb.iMapTileEdgeLengthInMeters);
-            TileNamer.Decode(s12km12kmMapTileName, out Envelope bounds12km);
+            Envelope bounds = tile.Common.TileScheme.Decode(tile.Name);
+            string s12km12kmMapTileName = tile.Common.TileScheme.Encode(bounds.MinX, bounds.MinY, TopographicDb.iMapTileEdgeLengthInMeters);
+            Envelope bounds12km = tile.Common.TileScheme.Decode(s12km12kmMapTileName);
 
             string sFullFilename = Path.Combine(tile.Common.DirectoryIntermediate, IRasterBuilder.Filename(tile.Name, _sRasterFilenameSpecifier, tile.Common.Version));
 
@@ -67,7 +67,7 @@ namespace Kuoste.TerrainEngine.TileBuilders.Rasters
                         return new ByteRaster();
 
                     // Save to filesystem
-                    string sTileName = TileNamer.Encode(x, y, TileCommon.EdgeLength);
+                    string sTileName = tile.Common.TileScheme.Encode(x, y, TileCommon.EdgeLength);
                     rasteriser.WriteAsAscii(
                         Path.Combine(tile.Common.DirectoryIntermediate, IRasterBuilder.Filename(sTileName, _sRasterFilenameSpecifier, tile.Common.Version)),
                         x, y, x + TileCommon.EdgeLength, y + TileCommon.EdgeLength);

--- a/TerrainEngine/TileBuilders/Trees/SimpleTreeCreator.cs
+++ b/TerrainEngine/TileBuilders/Trees/SimpleTreeCreator.cs
@@ -1,7 +1,6 @@
 using Kuoste.TerrainEngine.Common.Interfaces;
 using Kuoste.TerrainEngine.Common.Tiles;
 using LasUtility.Common;
-using LasUtility.Nls;
 using LasUtility.VoxelGrid;
 using NetTopologySuite.Geometries;
 using System;
@@ -27,7 +26,7 @@ namespace Kuoste.TerrainEngine.TileBuilders.Trees
 
         public List<Point> Build(Tile tile)
         {
-            TileNamer.Decode(tile.Name, out Envelope bounds);
+            Envelope bounds = tile.Common.TileScheme.Decode(tile.Name);
 
             List<Point> trees = new();
 

--- a/TerrainEngine/TileBuilders/Trees/TreeReader.cs
+++ b/TerrainEngine/TileBuilders/Trees/TreeReader.cs
@@ -1,6 +1,5 @@
 using Kuoste.TerrainEngine.Common.Interfaces;
 using Kuoste.TerrainEngine.Common.Tiles;
-using LasUtility.Nls;
 using NetTopologySuite.Geometries;
 using System;
 using System.Globalization;
@@ -20,7 +19,7 @@ namespace Kuoste.TerrainEngine.TileBuilders.Trees
             if (IsCancellationRequested())
                 return trees;
 
-            TileNamer.Decode(tile.Name, out Envelope bounds);
+            Envelope bounds = tile.Common.TileScheme.Decode(tile.Name);
             string sFullFilename = Path.Combine(tile.Common.DirectoryIntermediate, ITreeBuilder.Filename(tile.Name, tile.Common.Version));
 
             string[] sTrees = File.ReadAllText(sFullFilename).Split("Point");

--- a/TerrainEngine/TileBuilders/WaterAreas/WaterAreasCreator.cs
+++ b/TerrainEngine/TileBuilders/WaterAreas/WaterAreasCreator.cs
@@ -21,10 +21,10 @@ namespace Kuoste.TerrainEngine.TileBuilders.WaterAreas
                 return waterAreas;
 
             // Get topographic db tile name
-            TileNamer.Decode(tile.Name, out Envelope envBounds);
+            Envelope envBounds = tile.Common.TileScheme.Decode(tile.Name);
             GeometryFactory factory = new();
             Geometry bounds = factory.ToGeometry(envBounds);
-            string s12km12kmMapTileName = TileNamer.Encode((int)envBounds.MinX, (int)envBounds.MinY, TopographicDb.iMapTileEdgeLengthInMeters);
+            string s12km12kmMapTileName = tile.Common.TileScheme.Encode(envBounds.MinX, envBounds.MinY, TopographicDb.iMapTileEdgeLengthInMeters);
 
             string sFullFilename = Path.Combine(tile.Common.DirectoryOriginal, TopographicDb.sPrefixForTerrainType + s12km12kmMapTileName + TopographicDb.sPostfixForPolygon + ".shp");
 


### PR DESCRIPTION
First step of the terrain generalization plan (`docs/terrain-generalization-plan.md`, Phase 1): decouple the engine from hardcoded NLS Finland tile naming.

- **`Common/Interfaces/ITileScheme.cs`** — `Decode`/`Encode`/`EdgeLengthMeters`/`ParentTile`/`SubTiles`/`TilesInBounds`/`Neighbors`.
- **`Common/Tiles/NlsTileScheme.cs`** — wraps `LasUtility.Nls.TileNamer` (EPSG:3067); the default scheme.
- **`TileCommon`** carries an `ITileScheme` (optional ctor param, defaults to `NlsTileScheme`), so every builder reaches it via `tile.Common.TileScheme`.
- All 7 `TileBuilders` route `Decode`/`Encode` through the scheme. **Pure refactor, no behaviour change.**

`Neighbors`/`SubTiles`/`TilesInBounds` are implemented now (forward-looking for halo stitching and on-demand acquisition) though only `Decode`/`Encode` are wired in this phase. No default interface methods (Unity IL2CPP safety).

**Verified:** `dotnet test TerrainEngine.sln` green — Common 13/13, TileBuilders 40/40 (incl. the real-NLS-data integration suite that runs `DemDsmCreator` through the scheme).

**Scope: core only.** The Unity side (`TileManager`/`TileUpdater`/`TileRasterService`) still calls `TileNamer` directly (identical results since `NlsTileScheme` wraps it); routing it needs a `Runtime/dll/` re-vendor + Unity Test Runner and will follow as a separate issue.

Closes #42