### PR TITLE
Decouple tile sizes: configurable Output / Block / Source edge lengths

### DIFF
--- a/TerrainEngine/Common.Tests/Tiles/TileCommonTests.cs
+++ b/TerrainEngine/Common.Tests/Tiles/TileCommonTests.cs
@@ -6,9 +6,13 @@ namespace Kuoste.TerrainEngine.Common.Tests.Tiles;
 public class TileCommonTests
 {
     [Fact]
-    public void EdgeLength_IsOneThousand()
+    public void DefaultEdgeLengths_AreOutput1000_Block1000_Source3000()
     {
-        Assert.Equal(1000, TileCommon.EdgeLength);
+        var common = new TileCommon(256, "/i", "/o", "1");
+
+        Assert.Equal(1000, common.OutputEdgeLength);
+        Assert.Equal(1000, common.BlockEdgeLength);
+        Assert.Equal(3000, common.SourceEdgeLength);
     }
 
     [Fact]

--- a/TerrainEngine/Common/Tiles/TileCommon.cs
+++ b/TerrainEngine/Common/Tiles/TileCommon.cs
@@ -8,25 +8,34 @@ namespace Kuoste.TerrainEngine.Common.Tiles
     {
         public int AlphamapResolution { get; }
 
-        /// <summary>
-        /// Tile edge length in meters
-        /// </summary>
-        public const int EdgeLength = 1000;
         public string DirectoryIntermediate { get; }
         public string DirectoryOriginal { get; }
 
         public string Version { get; }
 
+        /// <summary>Edge length (m) of a consumption / output tile — one cached voxelgrid, one Unity terrain.</summary>
+        public int OutputEdgeLength { get; }
+
+        /// <summary>Edge length (m) of a triangulation block. Carried now, consumed in Phase 3; today equals the output tile.</summary>
+        public int BlockEdgeLength { get; }
+
+        /// <summary>Edge length (m) of a source point-cloud tile (the .laz extent).</summary>
+        public int SourceEdgeLength { get; }
+
         /// <summary>Tiling scheme that maps tile names to world coordinates. Defaults to NLS Finland.</summary>
         public ITileScheme TileScheme { get; }
 
-        public TileCommon(int alphamapResolution, string directoryIntermediate, string directoryOriginal, string version, ITileScheme? tileScheme = null)
+        public TileCommon(int alphamapResolution, string directoryIntermediate, string directoryOriginal, string version,
+            ITileScheme? tileScheme = null, int outputEdgeLength = 1000, int blockEdgeLength = 1000, int sourceEdgeLength = 3000)
         {
             AlphamapResolution = alphamapResolution;
             DirectoryIntermediate = directoryIntermediate;
             DirectoryOriginal = directoryOriginal;
             Version = version;
             TileScheme = tileScheme ?? new NlsTileScheme();
+            OutputEdgeLength = outputEdgeLength;
+            BlockEdgeLength = blockEdgeLength;
+            SourceEdgeLength = sourceEdgeLength;
         }
     }
 }

--- a/TerrainEngine/TileBuilders.Tests/Trees/SimpleTreeCreatorTests.cs
+++ b/TerrainEngine/TileBuilders.Tests/Trees/SimpleTreeCreatorTests.cs
@@ -24,7 +24,8 @@ public class SimpleTreeCreatorTests : IDisposable
     // where the DemDsm always has overlap. This keeps tile bounds strictly interior to
     // the grid so ProjToCell never hits the exclusive-max boundary.
     private const int OverlapMeters = 50;
-    private const int GridEdgeMeters = TileCommon.EdgeLength + 2 * OverlapMeters; // 1100 m
+    private const int OutputEdgeMeters = 1000; // default TileCommon.OutputEdgeLength
+    private const int GridEdgeMeters = OutputEdgeMeters + 2 * OverlapMeters; // 1100 m
     private const int GridSize = 110;  // 10 m/cell
     // Tree is placed at the grid cell that maps to the tile centre
     private const int CenterRow = GridSize / 2; // 55
@@ -125,8 +126,8 @@ public class SimpleTreeCreatorTests : IDisposable
     {
         // Extend beyond the tile on all sides so tile bounds are strictly interior
         var extent = new Envelope(
-            MinEast - OverlapMeters, MinEast + TileCommon.EdgeLength + OverlapMeters,
-            MinNorth - OverlapMeters, MinNorth + TileCommon.EdgeLength + OverlapMeters);
+            MinEast - OverlapMeters, MinEast + OutputEdgeMeters + OverlapMeters,
+            MinNorth - OverlapMeters, MinNorth + OutputEdgeMeters + OverlapMeters);
 
         var grid = VoxelGrid.CreateGrid(GridSize, GridSize, extent);
 

--- a/TerrainEngine/TileBuilders/DemDsm/DemDsmCreator.cs
+++ b/TerrainEngine/TileBuilders/DemDsm/DemDsmCreator.cs
@@ -19,7 +19,8 @@ namespace Kuoste.TerrainEngine.TileBuilders.DemDsm
         /// <summary>
         /// Use some overlap in triangulations or else the triangulations won't be complete on edges
         /// </summary>
-        const int _iOverlapInMeters = (_iTotalEdgeLengthInMeters - TileCommon.EdgeLength) / 2;
+        // 1000 = the legacy 1 km submesh size; this overlap/submesh mechanism is rewritten in Phase 3 (block triangulation).
+        const int _iOverlapInMeters = (_iTotalEdgeLengthInMeters - 1000) / 2;
 
         /// <summary>
         /// Total triangulation edge length
@@ -38,8 +39,10 @@ namespace Kuoste.TerrainEngine.TileBuilders.DemDsm
             if (IsCancellationRequested())
                 return new();
 
+            int iOutputEdge = tile.Common.OutputEdgeLength;
+
             Envelope bounds1km = tile.Common.TileScheme.Decode(tile.Name);
-            string s3km3kmTileName = tile.Common.TileScheme.Encode(bounds1km.MinX, bounds1km.MinY, 3000);
+            string s3km3kmTileName = tile.Common.TileScheme.Encode(bounds1km.MinX, bounds1km.MinY, tile.Common.SourceEdgeLength);
             Envelope bounds3km = tile.Common.TileScheme.Decode(s3km3kmTileName);
 
             // Check if the tile is already being processed
@@ -70,7 +73,7 @@ namespace Kuoste.TerrainEngine.TileBuilders.DemDsm
 
             reader.OpenReader(sFilename);
 
-            int iSubmeshesPerEdge = (int)Math.Round((reader.MaxX - reader.MinX) / TileCommon.EdgeLength);
+            int iSubmeshesPerEdge = (int)Math.Round((reader.MaxX - reader.MinX) / iOutputEdge);
             int iSubmeshCount = (int)Math.Pow(iSubmeshesPerEdge, 2);
 
             SurfaceTriangulation[] triangulations = new SurfaceTriangulation[iSubmeshCount];
@@ -110,23 +113,23 @@ namespace Kuoste.TerrainEngine.TileBuilders.DemDsm
                 int i3kmX = (int)(p.x - bounds3km.MinX);
                 int i3kmY = (int)(p.y - bounds3km.MinY);
 
-                AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX, i3kmY);
+                AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX, i3kmY);
 
                 // Look if point is part of another submesh overlap area.
                 // Overlap is needed because otherwise adjacent triangulated surfaces have a gap in between.
 
-                int iTileX = i3kmX % TileCommon.EdgeLength;
-                int iTileY = i3kmY % TileCommon.EdgeLength;
+                int iTileX = i3kmX % iOutputEdge;
+                int iTileY = i3kmY % iOutputEdge;
 
                 int iLowerBound = _iOverlapInMeters;
-                int iUpperBound = TileCommon.EdgeLength - _iOverlapInMeters;
+                int iUpperBound = iOutputEdge - _iOverlapInMeters;
                 int iMoveBy = _iOverlapInMeters;
 
                 if (iTileX < iLowerBound || iTileX > iUpperBound || iTileY < iLowerBound || iTileY > iUpperBound)
                 {
                     // This point also belongs to an overlap area of one or more other submesh.
 
-                    int iWholeMeshEdgeLength = TileCommon.EdgeLength * iSubmeshesPerEdge;
+                    int iWholeMeshEdgeLength = iOutputEdge * iSubmeshesPerEdge;
 
                     if (i3kmX < iLowerBound || i3kmX > iWholeMeshEdgeLength - iUpperBound ||
                         i3kmY < iLowerBound || i3kmY > iWholeMeshEdgeLength - iUpperBound)
@@ -140,92 +143,92 @@ namespace Kuoste.TerrainEngine.TileBuilders.DemDsm
                     if (iTileX < iLowerBound)
                     {
                         // West
-                        AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX - iMoveBy, i3kmY);
+                        AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX - iMoveBy, i3kmY);
 
                         if (iTileY < iLowerBound)
                         {
                             // Southwest
-                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX - iMoveBy, i3kmY - iMoveBy);
+                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX - iMoveBy, i3kmY - iMoveBy);
 
                             // South
-                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX, i3kmY - iMoveBy);
+                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX, i3kmY - iMoveBy);
                         }
                         else if (iTileY > iUpperBound)
                         {
                             // Northwest
-                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX - iMoveBy, i3kmY + iMoveBy);
+                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX - iMoveBy, i3kmY + iMoveBy);
 
                             // North
-                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX, i3kmY + iMoveBy);
+                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX, i3kmY + iMoveBy);
                         }
                     }
 
                     if (iTileX > iUpperBound)
                     {
                         // East
-                        AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX + iMoveBy, i3kmY);
+                        AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX + iMoveBy, i3kmY);
 
                         if (iTileY < iLowerBound)
                         {
                             // Southeast
-                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX + iMoveBy, i3kmY - iMoveBy);
+                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX + iMoveBy, i3kmY - iMoveBy);
 
                             // South
-                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX, i3kmY - iMoveBy);
+                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX, i3kmY - iMoveBy);
                         }
                         else if (iTileY > iUpperBound)
                         {
                             // Northeast
-                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX + iMoveBy, i3kmY + iMoveBy);
+                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX + iMoveBy, i3kmY + iMoveBy);
 
                             // North
-                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX, i3kmY + iMoveBy);
+                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX, i3kmY + iMoveBy);
                         }
                     }
 
                     if (iTileY < iLowerBound)
                     {
                         // South
-                        AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX, i3kmY - iMoveBy);
+                        AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX, i3kmY - iMoveBy);
 
                         if (iTileX < iLowerBound)
                         {
                             // Southwest
-                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX - iMoveBy, i3kmY - iMoveBy);
+                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX - iMoveBy, i3kmY - iMoveBy);
 
                             // West
-                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX - iMoveBy, i3kmY);
+                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX - iMoveBy, i3kmY);
                         }
                         else if (iTileX > iUpperBound)
                         {
                             // Southeast
-                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX + iMoveBy, i3kmY - iMoveBy);
+                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX + iMoveBy, i3kmY - iMoveBy);
 
                             // East
-                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX + iMoveBy, i3kmY);
+                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX + iMoveBy, i3kmY);
                         }
                     }
 
                     if (iTileY > iUpperBound)
                     {
                         // North
-                        AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX, i3kmY + iMoveBy);
+                        AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX, i3kmY + iMoveBy);
 
                         if (iTileX < iLowerBound)
                         {
                             // Northwest
-                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX - iMoveBy, i3kmY + iMoveBy);
+                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX - iMoveBy, i3kmY + iMoveBy);
 
                             // West
-                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX - iMoveBy, i3kmY);
+                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX - iMoveBy, i3kmY);
                         }
                         else if (iTileX > iUpperBound)
                         {
                             // Northeast
-                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX + iMoveBy, i3kmY + iMoveBy);
+                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX + iMoveBy, i3kmY + iMoveBy);
 
                             // East
-                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, i3kmX + iMoveBy, i3kmY);
+                            AddPoint(p, iSubmeshesPerEdge, triangulations, grids, lockedCells, iOutputEdge, i3kmX + iMoveBy, i3kmY);
                         }
                     }
                 }
@@ -315,11 +318,12 @@ namespace Kuoste.TerrainEngine.TileBuilders.DemDsm
             ITriangulation[] triangulations, 
             VoxelGrid[] grids,
             List<bool[,]> lockedCells,
-            int x, 
+            int iOutputEdge,
+            int x,
             int y)
         {
-            int ix = x / TileCommon.EdgeLength;
-            int iy = y / TileCommon.EdgeLength;
+            int ix = x / iOutputEdge;
+            int iy = y / iOutputEdge;
 
             if (ix < 0 || ix >= iSubmeshesPerEdge || iy < 0 || iy >= iSubmeshesPerEdge)
             {

--- a/TerrainEngine/TileBuilders/Rasters/RasterCreator.cs
+++ b/TerrainEngine/TileBuilders/Rasters/RasterCreator.cs
@@ -34,6 +34,8 @@ namespace Kuoste.TerrainEngine.TileBuilders.Rasters
             string s12km12kmMapTileName = tile.Common.TileScheme.Encode(bounds.MinX, bounds.MinY, TopographicDb.iMapTileEdgeLengthInMeters);
             Envelope bounds12km = tile.Common.TileScheme.Decode(s12km12kmMapTileName);
 
+            int iOutputEdge = tile.Common.OutputEdgeLength;
+
             string sFullFilename = Path.Combine(tile.Common.DirectoryIntermediate, IRasterBuilder.Filename(tile.Name, _sRasterFilenameSpecifier, tile.Common.Version));
 
             // Check if the tile is already being processed and add it to the dictionary if not.
@@ -49,7 +51,7 @@ namespace Kuoste.TerrainEngine.TileBuilders.Rasters
 
             Envelope rasterBounds = new(bounds12km);
 
-            int iRowAndColCount = TopographicDb.iMapTileEdgeLengthInMeters / TileCommon.EdgeLength * tile.Common.AlphamapResolution;
+            int iRowAndColCount = TopographicDb.iMapTileEdgeLengthInMeters / iOutputEdge * tile.Common.AlphamapResolution;
             rasteriser.InitializeRaster(iRowAndColCount, iRowAndColCount, rasterBounds);
 
             rasteriser.AddRasterizedClassesWithRasterValues(_nlsClassesToRasterValues);
@@ -59,25 +61,25 @@ namespace Kuoste.TerrainEngine.TileBuilders.Rasters
                 rasteriser.RasteriseShapefile(Path.Combine(tile.Common.DirectoryOriginal, sFilename));
             }
 
-            for (int x = (int)bounds12km.MinX; x < (int)bounds12km.MaxX; x += TileCommon.EdgeLength)
+            for (int x = (int)bounds12km.MinX; x < (int)bounds12km.MaxX; x += iOutputEdge)
             {
-                for (int y = (int)bounds12km.MinY; y < (int)bounds12km.MaxY; y += TileCommon.EdgeLength)
+                for (int y = (int)bounds12km.MinY; y < (int)bounds12km.MaxY; y += iOutputEdge)
                 {
                     if (IsCancellationRequested())
                         return new ByteRaster();
 
                     // Save to filesystem
-                    string sTileName = tile.Common.TileScheme.Encode(x, y, TileCommon.EdgeLength);
+                    string sTileName = tile.Common.TileScheme.Encode(x, y, iOutputEdge);
                     rasteriser.WriteAsAscii(
                         Path.Combine(tile.Common.DirectoryIntermediate, IRasterBuilder.Filename(sTileName, _sRasterFilenameSpecifier, tile.Common.Version)),
-                        x, y, x + TileCommon.EdgeLength, y + TileCommon.EdgeLength);
+                        x, y, x + iOutputEdge, y + iOutputEdge);
                 }
             }
 
             //rasteriser.WriteAsAscii(Path.Combine(tile.DirectoryIntermediate, s12km12kmMapTileName + "_full.asc"));
 
             return rasteriser.Crop((int)bounds.MinX, (int)bounds.MinY,
-                (int)bounds.MinX + TileCommon.EdgeLength, (int)bounds.MinY + TileCommon.EdgeLength);
+                (int)bounds.MinX + iOutputEdge, (int)bounds.MinY + iOutputEdge);
         }
 
         public void SetShpFilenames(string[] inputFilenames)

--- a/TerrainEngine/TileBuilders/Trees/SimpleTreeCreator.cs
+++ b/TerrainEngine/TileBuilders/Trees/SimpleTreeCreator.cs
@@ -27,6 +27,7 @@ namespace Kuoste.TerrainEngine.TileBuilders.Trees
         public List<Point> Build(Tile tile)
         {
             Envelope bounds = tile.Common.TileScheme.Decode(tile.Name);
+            int iOutputEdge = tile.Common.OutputEdgeLength;
 
             List<Point> trees = new();
 
@@ -121,7 +122,7 @@ namespace Kuoste.TerrainEngine.TileBuilders.Trees
                         streamWriter.Write($"[{(int)x},{(int)y},{(int)fNearbyMaxHeights}]");
                         streamWriter.WriteLine("}");
 
-                        trees.Add(new(((int)x - bounds.MinX) / TileCommon.EdgeLength, ((int)y - bounds.MinY) / TileCommon.EdgeLength, (int)fNearbyMaxHeights));
+                        trees.Add(new(((int)x - bounds.MinX) / iOutputEdge, ((int)y - bounds.MinY) / iOutputEdge, (int)fNearbyMaxHeights));
                     }
                 }
             }

--- a/TerrainEngine/TileBuilders/Trees/TreeReader.cs
+++ b/TerrainEngine/TileBuilders/Trees/TreeReader.cs
@@ -42,8 +42,8 @@ namespace Kuoste.TerrainEngine.TileBuilders.Trees
                     coords[2] = coords[2][..coords[2].IndexOf(']')];
 
                     trees.Add(new(
-                        (double.Parse(coords[0], CultureInfo.InvariantCulture) - bounds.MinX) / TileCommon.EdgeLength,
-                        (double.Parse(coords[1], CultureInfo.InvariantCulture) - bounds.MinY) / TileCommon.EdgeLength,
+                        (double.Parse(coords[0], CultureInfo.InvariantCulture) - bounds.MinX) / tile.Common.OutputEdgeLength,
+                        (double.Parse(coords[1], CultureInfo.InvariantCulture) - bounds.MinY) / tile.Common.OutputEdgeLength,
                         double.Parse(coords[2], CultureInfo.InvariantCulture)));
                 }
             }


### PR DESCRIPTION
Phase 2 of the terrain generalization plan (`docs/terrain-generalization-plan.md`). Replaces the conflated global `TileCommon.EdgeLength` const with **per-tile configuration**, **defaults reproducing today's behaviour** (no functional change).

- `TileCommon` now carries `OutputEdgeLength` (1000), `BlockEdgeLength` (1000), `SourceEdgeLength` (3000) — optional ctor params with those defaults. The `EdgeLength` const is **retired**.
- Builders read the knobs: `DemDsmCreator` uses `SourceEdgeLength` (was hardcoded `3000`) and a local `OutputEdgeLength` for the submesh math (the static `AddPoint` takes it as a parameter); `RasterCreator`/`SimpleTreeCreator`/`TreeReader` use `OutputEdgeLength`.
- Engine tests updated for the retired const (`TileCommonTests`, `SimpleTreeCreatorTests`).

**Notes:**
- `BlockEdgeLength` is carried but **not yet consumed** — Phase 3 (block triangulation) wires it. Mirrors how `ITileScheme.Neighbors` landed ahead of its consumer.
- `DemDsmCreator._iOverlapInMeters` now hardcodes `1000` (the legacy 1 km submesh) instead of the const; that overlap/submesh mechanism is rewritten in Phase 3.
- **Latent Unity item:** retiring the const means the Unity side (`TileManager`, `PlayModeTests/DemBuildTests`) still references `TileCommon.EdgeLength` and will need updating to `OutputEdgeLength` **when the `Runtime/dll/` is re-vendored** — folded into the deferred Unity-routing follow-up. Unity is unaffected until then (it builds against the current vendored DLL).

**Verified:** `dotnet test TerrainEngine.sln` green — Common 13/13, TileBuilders 40/40 (incl. the real-NLS-data integration suite).

Closes #46