### PR TITLE
Add CI: run the .NET test suite on push and PR

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -1,0 +1,40 @@
+name: .NET tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs on the same branch/PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: TerrainEngine test suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      - name: Restore
+        run: dotnet restore TerrainEngine/TerrainEngine.sln
+
+      # Debug config so the Release-only DLL-vendoring target stays out of CI.
+      # The integration tests read the committed Helsinki sample .laz from the repo.
+      - name: Test
+        run: dotnet test TerrainEngine/TerrainEngine.sln -c Debug --no-restore --logger "console;verbosity=normal"


### PR DESCRIPTION
## What & why

Adds a GitHub Actions workflow (`.github/workflows/dotnet-tests.yml`) so the TerrainEngine test suite runs automatically on:
- pushes to `main`
- pull requests targeting `main`

## Details

- **Runner:** `ubuntu-latest`, .NET 9 SDK via `actions/setup-dotnet`.
- **Command:** `dotnet test TerrainEngine/TerrainEngine.sln -c Debug` (Debug keeps the Release-only DLL-vendoring target out of CI).
- **No data setup needed:** the integration tests read the committed Helsinki sample `.laz`, and the Linux native LASzip (`laszip64.so`) is restored from the `laszipnetstandard` NuGet package.
- NuGet packages are cached; superseded runs on the same ref are cancelled.

This PR itself exercises the workflow (it targets `main`), so its own check run validates the config.