### PR TITLE
Removing stray verify line left by ruleset probe PR

### DIFF
--- a/docs/terrain-generalization-plan.md
+++ b/docs/terrain-generalization-plan.md
@@ -515,4 +515,3 @@ the DLL-vendoring story.)
 - Cross-source date-mismatch policy (LiDAR vs MTK vs 3D buildings).
 - Other-country providers: which Nordic first, and their CRS/formats/class mappings.
 - Probe lives at `D:\tmp\LazProbe` (outside repo) — delete when done.
-verify


### PR DESCRIPTION
Cleans up the throwaway line added by #55 while verifying the updated protect-main ruleset.